### PR TITLE
Drop id_list to_i conversion, because there are cases when PK is not integer

### DIFF
--- a/lib/komagire/id_list.rb
+++ b/lib/komagire/id_list.rb
@@ -23,10 +23,6 @@ module Komagire
       Converter.new(@content_class_name, @attribute, @delimiter).convert(cskeys)
     end
 
-    def _keys
-      super.map(&:to_i)
-    end
-
     def _find_by_cskeys
       ancestors = content_class_name.constantize.ancestors.map(&:to_s)
       if ancestors.include?('ActiveHash::Base')

--- a/spec/komagire/active_record_extension_spec.rb
+++ b/spec/komagire/active_record_extension_spec.rb
@@ -162,79 +162,131 @@ describe Komagire::ActiveRecordExtension do
   end
 
   describe '#composed_of_komagire_id_list with ActiveHash' do
-    class AhTag < ActiveHash::Base
-      self.data = [
-        {id: 1, name: 'ruby'},
-        {id: 2, name: 'perl'},
-        {id: 3, name: 'java'},
-      ]
+    context "when Id type is integer" do
+      class AhTag < ActiveHash::Base
+        self.data = [
+          {id: 1, name: 'ruby'},
+          {id: 2, name: 'perl'},
+          {id: 3, name: 'java'},
+        ]
+      end
+
+      create_temp_table :post_ahs do |t|
+        t.string :tag_ids
+      end
+
+      class PostAh < ActiveRecord::Base
+        composed_of_komagire_id_list :tags, :tag_ids, 'AhTag', komagire: {delimiter: ':'}
+      end
+
+      let(:post) { PostAh.new }
+
+      it 'empty' do
+        post.tags = ''
+        expect(post.tag_ids).to eq ':'
+        post.save!
+        expect(post.tag_ids).to eq ':'
+      end
+
+      it 'should ignore not exist id ' do
+        post.tags = '100:1'
+        expect(post.tag_ids).to eq ':1:'
+        post.save!
+        expect(post.tag_ids).to eq ':1:'
+      end
+
+      it 'should ignore duplicate id' do
+        post.tags = '1:2:1'
+        expect(post.tag_ids).to eq ':1:2:'
+        post.save!
+        expect(post.tag_ids).to eq ':1:2:'
+      end
+
+      it 'should convert from string' do
+        post.tags = '1:2:3'
+        expect(post.tag_ids).to eq ':1:2:3:'
+        post.save!
+        expect(post.tag_ids).to eq ':1:2:3:'
+      end
+
+      it 'should convert from Komagire::IdList' do
+        list = Komagire::IdList.new('AhTag', '1:3', delimiter: ':')
+        post.tags = list
+        expect(post.tag_ids).to eq ':1:3:'
+        post.save!
+        expect(post.tag_ids).to eq ':1:3:'
+      end
+
+      it 'should convert from Array of String' do
+        post.tags = ['3', '2']
+        expect(post.tag_ids).to eq ':2:3:'
+        post.save!
+        expect(post.tag_ids).to eq ':2:3:'
+      end
+
+      it 'should convert from Array of Integer' do
+        post.tags = [3, 2]
+        expect(post.tag_ids).to eq ':2:3:'
+        post.save!
+        expect(post.tag_ids).to eq ':2:3:'
+      end
+
+      it 'should convert from Array of Tag' do
+        post.tags = [AhTag.find(1)]
+        expect(post.tag_ids).to eq ':1:'
+        post.save!
+        expect(post.tag_ids).to eq ':1:'
+      end
     end
 
-    create_temp_table :post_ahs do |t|
-      t.string :tag_ids
-    end
+    context 'when Id type is string' do
+      class ProductType < ActiveHash::Base
+        include ActiveHash::Enum
+        self.data = [
+          {id: 'bacon', name: 'Bacon'},
+          {id: 'lettuce', name: 'Lettuce'},
+          {id: 'tomato', name: 'Tomato'},
+        ]
+        enum_accessor :id
+      end
 
-    class PostAh < ActiveRecord::Base
-      composed_of_komagire_id_list :tags, :tag_ids, 'AhTag', komagire: {delimiter: ':'}
-    end
+      create_temp_table :products do |t|
+        t.string :product_type_ids
+      end
 
-    let(:post) { PostAh.new }
+      class Product < ActiveRecord::Base
+        composed_of_komagire_id_list :product_types, :product_type_ids, 'ProductType'
+      end
 
-    it 'empty' do
-      post.tags = ''
-      expect(post.tag_ids).to eq ':'
-      post.save!
-      expect(post.tag_ids).to eq ':'
-    end
+      let(:product) { Product.new }
 
-    it 'should ignore not exist id ' do
-      post.tags = '100:1'
-      expect(post.tag_ids).to eq ':1:'
-      post.save!
-      expect(post.tag_ids).to eq ':1:'
-    end
+      it 'should be ignore not exist key' do
+        product.product_types = "peamon"
+        expect(product.product_type_ids).to eq ','
+        product.save!
+        expect(product.product_type_ids).to eq ','
+      end
 
-    it 'should ignore duplicate id' do
-      post.tags = '1:2:1'
-      expect(post.tag_ids).to eq ':1:2:'
-      post.save!
-      expect(post.tag_ids).to eq ':1:2:'
-    end
+      it 'should be convertible from string' do
+        product.product_types = "bacon,tomato"
+        expect(product.product_type_ids).to eq ',bacon,tomato,'
+        product.save!
+        expect(product.product_type_ids).to eq ',bacon,tomato,'
+      end
 
-    it 'should convert from string' do
-      post.tags = '1:2:3'
-      expect(post.tag_ids).to eq ':1:2:3:'
-      post.save!
-      expect(post.tag_ids).to eq ':1:2:3:'
-    end
+      it 'should be convertible from Array of Strings' do
+        product.product_types = ['bacon', 'tomato']
+        expect(product.product_type_ids).to eq ',bacon,tomato,'
+        product.save!
+        expect(product.product_type_ids).to eq ',bacon,tomato,'
+      end
 
-    it 'should convert from Komagire::IdList' do
-      list = Komagire::IdList.new('AhTag', '1:3', delimiter: ':')
-      post.tags = list
-      expect(post.tag_ids).to eq ':1:3:'
-      post.save!
-      expect(post.tag_ids).to eq ':1:3:'
-    end
-
-    it 'should convert from Array of String' do
-      post.tags = ['3', '2']
-      expect(post.tag_ids).to eq ':2:3:'
-      post.save!
-      expect(post.tag_ids).to eq ':2:3:'
-    end
-
-    it 'should convert from Array of Integer' do
-      post.tags = [3, 2]
-      expect(post.tag_ids).to eq ':2:3:'
-      post.save!
-      expect(post.tag_ids).to eq ':2:3:'
-    end
-
-    it 'should convert from Array of Tag' do
-      post.tags = [AhTag.find(1)]
-      expect(post.tag_ids).to eq ':1:'
-      post.save!
-      expect(post.tag_ids).to eq ':1:'
+      it 'should be convertible from Array of ProductType' do
+        product.product_types = [ProductType::BACON, ProductType::TOMATO]
+        expect(product.product_type_ids).to eq ',bacon,tomato,'
+        product.save!
+        expect(product.product_type_ids).to eq ',bacon,tomato,'
+      end
     end
   end
 end


### PR DESCRIPTION
When PrimaryKey type is not integer, Komagire id_list is not work fine, so i fix it.
