### PR TITLE
Fix deprecation warning of simplecov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'bundler/setup'
 require 'simplecov'
 require 'coveralls'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]


### PR DESCRIPTION
Fix follow deprecation warning of simplecov
```
/home/travis/build/troter/komagire/spec/spec_helper.rb:8:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.
```
https://travis-ci.org/troter/komagire/jobs/143231879#L234