### PR TITLE
Prevent extra query when cskeys are empty

### DIFF
--- a/lib/komagire/key_list.rb
+++ b/lib/komagire/key_list.rb
@@ -52,6 +52,8 @@ module Komagire
     end
 
     def _find_by_cskeys
+      return [] if _keys.empty?
+
       values = content_class_name.constantize.where(@attribute => _keys).compact
       if @sort
         values.sort_by { |v| v.public_send(@attribute) }

--- a/lib/komagire/key_list.rb
+++ b/lib/komagire/key_list.rb
@@ -52,13 +52,14 @@ module Komagire
     end
 
     def _find_by_cskeys
-      return [] if _keys.empty?
+      keys = _keys
+      return [] if keys.empty?
 
-      values = content_class_name.constantize.where(@attribute => _keys).compact
+      values = content_class_name.constantize.where(@attribute => keys).compact
       if @sort
         values.sort_by { |v| v.public_send(@attribute) }
       else
-        values.index_by { |v| v.public_send(@attribute).to_s }.values_at(*_keys)
+        values.index_by { |v| v.public_send(@attribute).to_s }.values_at(*keys)
       end
     end
 

--- a/spec/komagire/active_record_extension_spec.rb
+++ b/spec/komagire/active_record_extension_spec.rb
@@ -25,7 +25,9 @@ describe Komagire::ActiveRecordExtension do
 
     let(:post) { PostName.new }
 
-    it 'empty' do
+    it 'should be empty without query' do
+      expect(Tag).not_to receive(:where)
+
       post.tags = ''
       expect(post.tag_names).to eq '|'
       post.save!
@@ -114,7 +116,9 @@ describe Komagire::ActiveRecordExtension do
 
     let(:post) { PostId.new }
 
-    it 'empty' do
+    it 'should be empty without query' do
+      expect(Tag).not_to receive(:where)
+
       post.tags = ''
       expect(post.tag_ids).to eq ','
       post.save!
@@ -199,7 +203,7 @@ describe Komagire::ActiveRecordExtension do
 
       let(:post) { PostAh.new }
 
-      it 'empty' do
+      it 'should be empty' do
         post.tags = ''
         expect(post.tag_ids).to eq ':'
         post.save!


### PR DESCRIPTION
I fixed to prevent extra query (e.g. `SELECT "tags".* FROM "tags" WHERE 1=0`) when cskeys are empty.

