### PR TITLE
Avoid needless override

### DIFF
--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -2,7 +2,7 @@
 
 source 'http://rubygems.org/'
 
-gem 'activerecord', '~> 6.1.0.rc1'
-gem 'activesupport', '~> 6.1.0.rc1'
+gem 'activerecord', '~> 6.1.0'
+gem 'activesupport', '~> 6.1.0'
 
 gemspec path: '../'

--- a/lib/komagire/key_list.rb
+++ b/lib/komagire/key_list.rb
@@ -32,15 +32,6 @@ module Komagire
       ([''] + key_values + ['']).join(@delimiter)
     end
 
-    def freeze
-      case __getobj__
-      when ActiveRecord::Relation
-        # avoid ActiveRecord::Relation is frozen
-      else
-        super
-      end
-    end
-
     private
 
     def _convert(cskeys)


### PR DESCRIPTION
In v0.2.0, the sort option was introduced and `_find_by_cskeys` was changed to always returns an `Array` object.
`__getobj__` no longer returns `ActiveRecord::Relation` because it returns the value of `_find_by_cskeys`.

ref. 0adff44e1e8f7e0268f851dc7aa7ea54bb0b5d1a